### PR TITLE
Add SSO support, by getting info from session

### DIFF
--- a/app/controllers/blacklight_cornell_requests/request_controller.rb
+++ b/app/controllers/blacklight_cornell_requests/request_controller.rb
@@ -58,6 +58,7 @@ module BlacklightCornellRequests
       session_holdings = session[:holdings_status_short]
       session[:holdings_status_short] = nil
       req = BlacklightCornellRequests::Request.new(@id, session_holdings)
+      binding.pry
       req.netid = request.env['REMOTE_USER'] ? request.env['REMOTE_USER']  : session[:cu_authenticated_user] 
       req.netid.sub!('@CORNELL.EDU', '') unless req.netid.nil?
       req.netid.sub!('@cornell.edu', '') unless req.netid.nil?

--- a/app/controllers/blacklight_cornell_requests/request_controller.rb
+++ b/app/controllers/blacklight_cornell_requests/request_controller.rb
@@ -23,6 +23,12 @@ module BlacklightCornellRequests
       document
     end
 
+    def auth_magic_request target=''
+    session[:cuwebauth_return_path] =  magic_request_path(params[:bibid])
+    Rails.logger.debug "es287_log #{__FILE__} #{__LINE__}: #{magic_request_path(params[:bibid]).inspect}"
+    redirect_to "#{request.protocol}#{request.host_with_port}/users/auth/saml"
+    end
+
     def magic_request target=''
 
       @id = params[:bibid]
@@ -52,8 +58,9 @@ module BlacklightCornellRequests
       session_holdings = session[:holdings_status_short]
       session[:holdings_status_short] = nil
       req = BlacklightCornellRequests::Request.new(@id, session_holdings)
-      req.netid = request.env['REMOTE_USER']
+      req.netid = request.env['REMOTE_USER'] ? request.env['REMOTE_USER']  : session[:cu_authenticated_user] 
       req.netid.sub!('@CORNELL.EDU', '') unless req.netid.nil?
+      req.netid.sub!('@cornell.edu', '') unless req.netid.nil?
 
       # When we're entering the request system from a /catalog path, then we're starting
       # fresh — no volume should be pre-selected (or kept in the session). However,

--- a/app/controllers/blacklight_cornell_requests/request_controller.rb
+++ b/app/controllers/blacklight_cornell_requests/request_controller.rb
@@ -58,7 +58,6 @@ module BlacklightCornellRequests
       session_holdings = session[:holdings_status_short]
       session[:holdings_status_short] = nil
       req = BlacklightCornellRequests::Request.new(@id, session_holdings)
-      binding.pry
       req.netid = request.env['REMOTE_USER'] ? request.env['REMOTE_USER']  : session[:cu_authenticated_user] 
       req.netid.sub!('@CORNELL.EDU', '') unless req.netid.nil?
       req.netid.sub!('@cornell.edu', '') unless req.netid.nil?

--- a/app/helpers/blacklight_cornell_requests/application_helper.rb
+++ b/app/helpers/blacklight_cornell_requests/application_helper.rb
@@ -12,7 +12,7 @@ module BlacklightCornellRequests
       end
     end
 
-    def respond_to?(method)
+    def respond_to?(method,include_all=false)
       if method.to_s.end_with?('_path') or method.to_s.end_with?('_url')
         if main_app.respond_to?(method)
           true

--- a/app/views/blacklight_cornell_requests/request/bd.html.haml
+++ b/app/views/blacklight_cornell_requests/request/bd.html.haml
@@ -3,7 +3,7 @@
 - @selected_volume = params[:volume]
 = render :partial => 'shared/back_to_item'
 %h2
-  - user = request.env['REMOTE_USER'].inspect
+  - user = request.env['REMOTE_USER'] ? request.env['REMOTE_USER']  : session[:cu_authenticated_user] 
   = "Borrow Direct Request for " + user
 %div.well
   %h3.item-title-request.blacklight-title_display

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ BlacklightCornellRequests::Engine.routes.draw do
 
   put '/:bibid' => 'request#magic_request', :as => 'magic_request_bibid'
   get '/:bibid' => 'request#magic_request', :as => 'magic_request'
+  get 'auth/:bibid' => 'request#auth_magic_request', :as => 'auth_magic_request'
   #get '/:bibid/:volume' => 'request#magic_request', :as => 'volume_request', :constraints => { :volume => /.*/ } 
   get 'volume/set' => 'request#set_volume'#, :as => 'set_volume'
 

--- a/lib/blacklight_cornell_requests/version.rb
+++ b/lib/blacklight_cornell_requests/version.rb
@@ -1,3 +1,3 @@
 module BlacklightCornellRequests
-  VERSION = "1.4.2"
+  VERSION = "1.4.3"
 end

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,5 +1,9 @@
 # Release Notes - blacklight-cornell-requests 
 
+## v1.4.3
+### Improvements
+- Allow operation with SAML 
+
 ## v1.4.2
 
 ### Improvements


### PR DESCRIPTION
Matt, I set up some code to handle SAML login, let me know if this looks okay to
you.  it ought to also work with cuwebauth -- since the SAML code is mostly
in one method, and we only use the session provided  authenticated user if REMOTE_USER is not set.

