### PR TITLE
Fix a bug in creation of ILL links with 'dirty' ISBNs

### DIFF
--- a/app/models/blacklight_cornell_requests/request.rb
+++ b/app/models/blacklight_cornell_requests/request.rb
@@ -987,7 +987,11 @@ module BlacklightCornellRequests
       document = self.document
       ill_link = ENV['ILLIAD_URL'] + '?Action=10&Form=30&url_ver=Z39.88-2004&rfr_id=info%3Asid%2Flibrary.cornell.edu'
       if self.isbn.present?
-        isbns = self.isbn.join(',')
+        # Caitlin says that the ILLiad form has a field limit once it's submitted,
+        # so there isn't much point in passing in more than the first ISBN (though
+        # some records could have a dozen or more)
+        isbns = self.isbn.map!{|i| i = i.clean_isbn}[0]
+
         ill_link = ill_link + "&rft.isbn=#{isbns}"
         ill_link = ill_link + "&rft_id=urn%3AISBN%3A#{isbns}"
       end

--- a/lib/blacklight_cornell_requests/version.rb
+++ b/lib/blacklight_cornell_requests/version.rb
@@ -1,3 +1,3 @@
 module BlacklightCornellRequests
-  VERSION = "1.5.4"
+  VERSION = "1.5.5"
 end

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,5 +1,8 @@
 # Release Notes - blacklight-cornell-requests
 
+## v1.5.5
+- Fixed a bug in formation of ILLiad links with ISBNs with additional text; only pass in the first ISBN (DISCOVERYACCESS-4106).
+
 ## v1.5.4
 
 ### Bug fixes


### PR DESCRIPTION
DISCOVERYACCESS-4106