### PR TITLE
Discoveryaccess 7436

### DIFF
--- a/app/controllers/blacklight_cornell_requests/request_controller.rb
+++ b/app/controllers/blacklight_cornell_requests/request_controller.rb
@@ -33,38 +33,9 @@ module BlacklightCornellRequests
       if uri.port.present? && uri.port !=  uri.default_port()
         scheme_host = scheme_host + ':' + uri.port.to_s
       end
-#******************
-save_level = Rails.logger.level; Rails.logger.level = Logger::WARN
-jgr25_context = "#{__FILE__}:#{__LINE__}"
-Rails.logger.warn "jgr25_log\n#{jgr25_context}:"
-msg = [" #{__method__} ".center(60,'Z')]
-msg << jgr25_context
-msg << "request.original_url: " + request.original_url.inspect
-msg << "uri: " + uri.inspect
-msg << 'Z' * 60
-msg.each { |x| puts 'ZZZ ' + x.to_yaml }
-Rails.logger.level = save_level
-#binding.pry
-#*******************
       id_format = params[:format].present? ? params[:bibid] + '.' + params[:format] : params[:bibid]
       session[:cuwebauth_return_path] = magic_request_path(id_format)
       Rails.logger.debug "es287_log #{__FILE__} #{__LINE__}: #{magic_request_path(id_format).inspect}"
-      Rails.logger.debug "es287_log #{__FILE__} #{__LINE__}: #{request.original_url.inspect}"
-#******************
-save_level = Rails.logger.level; Rails.logger.level = Logger::WARN
-msg.each { |x| puts 'ZZZ ' + x.to_yaml }
-jgr25_context = "#{__FILE__}:#{__LINE__}"
-Rails.logger.warn "jgr25_log\n#{jgr25_context}:"
-msg = [" #{__method__} ".center(60,'Z')]
-msg << jgr25_context
-msg << "request.original_url: " + request.original_url.inspect
-msg << "uri: " + uri.inspect
-msg << "scheme_host: " + scheme_host.inspect
-msg << 'Z' * 60
-msg.each { |x| puts 'ZZZ ' + x.to_yaml }
-Rails.logger.level = save_level
-#binding.pry
-#*******************
       if ENV['DEBUG_USER'] && Rails.env.development?
         magic_request target
       else

--- a/app/controllers/blacklight_cornell_requests/request_controller.rb
+++ b/app/controllers/blacklight_cornell_requests/request_controller.rb
@@ -28,8 +28,8 @@ module BlacklightCornellRequests
     end
 
     def auth_magic_request target=''
-      uri = URI(request.original_url)
-      scheme_host_port = "#{uri.scheme}://#{uri.host}" + (uri.port == 80) ? '' : ':' + uri.port
+      # uri = URI(request.original_url)
+      # scheme_host_port = "#{uri.scheme}://#{uri.host}" + (uri.port == 80) ? '' : ':' + uri.port
       id_format = params[:format].present? ? params[:bibid] + '.' + params[:format] : params[:bibid]
       session[:cuwebauth_return_path] = magic_request_path(id_format)
       Rails.logger.debug "es287_log #{__FILE__} #{__LINE__}: #{magic_request_path(id_format).inspect}"

--- a/app/controllers/blacklight_cornell_requests/request_controller.rb
+++ b/app/controllers/blacklight_cornell_requests/request_controller.rb
@@ -31,7 +31,7 @@ module BlacklightCornellRequests
       uri = URI(request.original_url)
       scheme_host_port = "#{uri.scheme}://#{uri.host}" + (uri.port == 80) ? '' : ':' + uri.port
       id_format = params[:format].present? ? params[:bibid] + '.' + params[:format] : params[:bibid]
-      session[:cuwebauth_return_path] = scheme_host_port + magic_request_path(id_format)
+      session[:cuwebauth_return_path] = magic_request_path(id_format)
       Rails.logger.debug "es287_log #{__FILE__} #{__LINE__}: #{magic_request_path(id_format).inspect}"
 #******************
 save_level = Rails.logger.level; Rails.logger.level = Logger::WARN

--- a/app/controllers/blacklight_cornell_requests/request_controller.rb
+++ b/app/controllers/blacklight_cornell_requests/request_controller.rb
@@ -29,6 +29,10 @@ module BlacklightCornellRequests
 
     def auth_magic_request target=''
       uri = URI(request.original_url)
+      scheme_host = "#{uri.scheme}://#{uri.host}"
+      if uri.port.present? && uri.port !=  uri.default_port()
+        scheme_host = scheme_host + ':' + uri.port.to_s
+      end
 #******************
 save_level = Rails.logger.level; Rails.logger.level = Logger::WARN
 jgr25_context = "#{__FILE__}:#{__LINE__}"
@@ -42,10 +46,6 @@ msg.each { |x| puts 'ZZZ ' + x.to_yaml }
 Rails.logger.level = save_level
 #binding.pry
 #*******************
-      scheme_host = "#{uri.scheme}://#{uri.host}"
-      if uri.port.present? && uri.port !=  uri.default_port()
-        scheme_host = scheme_host + ':' + uri.port
-      end
       id_format = params[:format].present? ? params[:bibid] + '.' + params[:format] : params[:bibid]
       session[:cuwebauth_return_path] = magic_request_path(id_format)
       Rails.logger.debug "es287_log #{__FILE__} #{__LINE__}: #{magic_request_path(id_format).inspect}"

--- a/app/controllers/blacklight_cornell_requests/request_controller.rb
+++ b/app/controllers/blacklight_cornell_requests/request_controller.rb
@@ -28,25 +28,25 @@ module BlacklightCornellRequests
     end
 
     def auth_magic_request target=''
-      # uri = URI(request.original_url)
-      # scheme_host_port = "#{uri.scheme}://#{uri.host}" + (uri.port == 80) ? '' : ':' + uri.port
+      uri = URI(request.original_url)
+      scheme_host_port = "#{uri.scheme}://#{uri.host}" + (uri.port == 80) ? '' : ':' + uri.port
       id_format = params[:format].present? ? params[:bibid] + '.' + params[:format] : params[:bibid]
       session[:cuwebauth_return_path] = magic_request_path(id_format)
       Rails.logger.debug "es287_log #{__FILE__} #{__LINE__}: #{magic_request_path(id_format).inspect}"
       Rails.logger.debug "es287_log #{__FILE__} #{__LINE__}: #{request.original_url.inspect}"
 #******************
-# save_level = Rails.logger.level; Rails.logger.level = Logger::WARN
-# msg.each { |x| puts 'ZZZ ' + x.to_yaml }
-# jgr25_context = "#{__FILE__}:#{__LINE__}"
-# Rails.logger.warn "jgr25_log\n#{jgr25_context}:"
-# msg = [" #{__method__} ".center(60,'Z')]
-# msg << jgr25_context
-# msg << "request.original_url: " + request.original_url.inspect
-# msg << "uri: " + uri.inspect
-# msg << "scheme_host_port: " + scheme_host_port.inspect
-# msg << 'Z' * 60
-# msg.each { |x| puts 'ZZZ ' + x.to_yaml }
-# Rails.logger.level = save_level
+save_level = Rails.logger.level; Rails.logger.level = Logger::WARN
+msg.each { |x| puts 'ZZZ ' + x.to_yaml }
+jgr25_context = "#{__FILE__}:#{__LINE__}"
+Rails.logger.warn "jgr25_log\n#{jgr25_context}:"
+msg = [" #{__method__} ".center(60,'Z')]
+msg << jgr25_context
+msg << "request.original_url: " + request.original_url.inspect
+msg << "uri: " + uri.inspect
+msg << "scheme_host_port: " + scheme_host_port.inspect
+msg << 'Z' * 60
+msg.each { |x| puts 'ZZZ ' + x.to_yaml }
+Rails.logger.level = save_level
 #binding.pry
 #*******************
       if ENV['DEBUG_USER'] && Rails.env.development?

--- a/app/controllers/blacklight_cornell_requests/request_controller.rb
+++ b/app/controllers/blacklight_cornell_requests/request_controller.rb
@@ -33,19 +33,20 @@ module BlacklightCornellRequests
       id_format = params[:format].present? ? params[:bibid] + '.' + params[:format] : params[:bibid]
       session[:cuwebauth_return_path] = magic_request_path(id_format)
       Rails.logger.debug "es287_log #{__FILE__} #{__LINE__}: #{magic_request_path(id_format).inspect}"
+      Rails.logger.debug "es287_log #{__FILE__} #{__LINE__}: #{request.original_url.inspect}"
 #******************
-save_level = Rails.logger.level; Rails.logger.level = Logger::WARN
-msg.each { |x| puts 'ZZZ ' + x.to_yaml }
-jgr25_context = "#{__FILE__}:#{__LINE__}"
-Rails.logger.warn "jgr25_log\n#{jgr25_context}:"
-msg = [" #{__method__} ".center(60,'Z')]
-msg << jgr25_context
-msg << "request.original_url: " + request.original_url.inspect
-msg << "uri: " + uri.inspect
-msg << "scheme_host_port: " + scheme_host_port.inspect
-msg << 'Z' * 60
-msg.each { |x| puts 'ZZZ ' + x.to_yaml }
-Rails.logger.level = save_level
+# save_level = Rails.logger.level; Rails.logger.level = Logger::WARN
+# msg.each { |x| puts 'ZZZ ' + x.to_yaml }
+# jgr25_context = "#{__FILE__}:#{__LINE__}"
+# Rails.logger.warn "jgr25_log\n#{jgr25_context}:"
+# msg = [" #{__method__} ".center(60,'Z')]
+# msg << jgr25_context
+# msg << "request.original_url: " + request.original_url.inspect
+# msg << "uri: " + uri.inspect
+# msg << "scheme_host_port: " + scheme_host_port.inspect
+# msg << 'Z' * 60
+# msg.each { |x| puts 'ZZZ ' + x.to_yaml }
+# Rails.logger.level = save_level
 #binding.pry
 #*******************
       if ENV['DEBUG_USER'] && Rails.env.development?

--- a/app/controllers/blacklight_cornell_requests/request_controller.rb
+++ b/app/controllers/blacklight_cornell_requests/request_controller.rb
@@ -31,7 +31,6 @@ module BlacklightCornellRequests
       uri = URI(request.original_url)
 #******************
 save_level = Rails.logger.level; Rails.logger.level = Logger::WARN
-msg.each { |x| puts 'ZZZ ' + x.to_yaml }
 jgr25_context = "#{__FILE__}:#{__LINE__}"
 Rails.logger.warn "jgr25_log\n#{jgr25_context}:"
 msg = [" #{__method__} ".center(60,'Z')]

--- a/app/controllers/blacklight_cornell_requests/request_controller.rb
+++ b/app/controllers/blacklight_cornell_requests/request_controller.rb
@@ -33,8 +33,22 @@ module BlacklightCornellRequests
       id_format = params[:format].present? ? params[:bibid] + '.' + params[:format] : params[:bibid]
       session[:cuwebauth_return_path] = scheme_host_port + magic_request_path(id_format)
       Rails.logger.debug "es287_log #{__FILE__} #{__LINE__}: #{magic_request_path(id_format).inspect}"
-      Rails.logger.debug "jgr25_log #{__FILE__} #{__LINE__}: #{session[:cuwebauth_return_path].inspect}"
-      if ENV['DEBUG_USER'] && Rails.env.development?
+#******************
+save_level = Rails.logger.level; Rails.logger.level = Logger::WARN
+msg.each { |x| puts 'ZZZ ' + x.to_yaml }
+jgr25_context = "#{__FILE__}:#{__LINE__}"
+Rails.logger.warn "jgr25_log\n#{jgr25_context}:"
+msg = [" #{__method__} ".center(60,'Z')]
+msg << jgr25_context
+msg << "request.original_url: " + request.original_url.inspect
+msg << "scheme_host_port: " + scheme_host_port.inspect
+msg << "session[:cuwebauth_return_path]: " + session[:cuwebauth_return_path].inspect
+msg << 'Z' * 60
+msg.each { |x| puts 'ZZZ ' + x.to_yaml }
+Rails.logger.level = save_level
+#binding.pry
+#*******************
+%      if ENV['DEBUG_USER'] && Rails.env.development?
         magic_request target
       else
         # Replace redirect_to with redirect_post (from repost gem) to deal with new

--- a/app/controllers/blacklight_cornell_requests/request_controller.rb
+++ b/app/controllers/blacklight_cornell_requests/request_controller.rb
@@ -41,14 +41,14 @@ Rails.logger.warn "jgr25_log\n#{jgr25_context}:"
 msg = [" #{__method__} ".center(60,'Z')]
 msg << jgr25_context
 msg << "request.original_url: " + request.original_url.inspect
+msg << "uri: " + uri.inspect
 msg << "scheme_host_port: " + scheme_host_port.inspect
-msg << "session[:cuwebauth_return_path]: " + session[:cuwebauth_return_path].inspect
 msg << 'Z' * 60
 msg.each { |x| puts 'ZZZ ' + x.to_yaml }
 Rails.logger.level = save_level
 #binding.pry
 #*******************
-%      if ENV['DEBUG_USER'] && Rails.env.development?
+      if ENV['DEBUG_USER'] && Rails.env.development?
         magic_request target
       else
         # Replace redirect_to with redirect_post (from repost gem) to deal with new

--- a/app/controllers/blacklight_cornell_requests/request_controller.rb
+++ b/app/controllers/blacklight_cornell_requests/request_controller.rb
@@ -36,7 +36,7 @@ module BlacklightCornellRequests
       else
         # Replace redirect_to with redirect_post (from repost gem) to deal with new
         # Omniauth gem requirements
-        redirect_post "#{request.protocol}#{request.host_with_port}/users/auth/saml"
+        redirect_post("#{request.protocol}#{request.host_with_port}/users/auth/saml", options: {authenticity_token: :auto})
       end
     end
 

--- a/app/controllers/blacklight_cornell_requests/request_controller.rb
+++ b/app/controllers/blacklight_cornell_requests/request_controller.rb
@@ -36,7 +36,9 @@ module BlacklightCornellRequests
       else
         # Replace redirect_to with redirect_post (from repost gem) to deal with new
         # Omniauth gem requirements
-        redirect_post("#{request.protocol}#{request.host_with_port}/users/auth/saml", options: {authenticity_token: :auto})
+        uri = URI(request.original_url)
+        host_port = uri.host + (uri.port == 80) ? '' : ':' + uri.port
+        redirect_post("#{uri.scheme}://#{host_port}/users/auth/saml", options: {authenticity_token: :auto})
       end
     end
 

--- a/app/controllers/blacklight_cornell_requests/request_controller.rb
+++ b/app/controllers/blacklight_cornell_requests/request_controller.rb
@@ -57,7 +57,7 @@ Rails.logger.level = save_level
       else
         # Replace redirect_to with redirect_post (from repost gem) to deal with new
         # Omniauth gem requirements
-        redirect_post("#{scheme_host_port}/users/auth/saml", options: {authenticity_token: :auto})
+        redirect_post("#{scheme_host}/users/auth/saml", options: {authenticity_token: :auto})
       end
     end
 

--- a/app/controllers/blacklight_cornell_requests/request_controller.rb
+++ b/app/controllers/blacklight_cornell_requests/request_controller.rb
@@ -28,17 +28,18 @@ module BlacklightCornellRequests
     end
 
     def auth_magic_request target=''
+      uri = URI(request.original_url)
+      scheme_host_port = "#{uri.scheme}://#{uri.host}" + (uri.port == 80) ? '' : ':' + uri.port
       id_format = params[:format].present? ? params[:bibid] + '.' + params[:format] : params[:bibid]
-      session[:cuwebauth_return_path] = magic_request_path(id_format)
+      session[:cuwebauth_return_path] = scheme_host_port + magic_request_path(id_format)
       Rails.logger.debug "es287_log #{__FILE__} #{__LINE__}: #{magic_request_path(id_format).inspect}"
+      Rails.logger.debug "jgr25_log #{__FILE__} #{__LINE__}: #{session[:cuwebauth_return_path].inspect}"
       if ENV['DEBUG_USER'] && Rails.env.development?
         magic_request target
       else
         # Replace redirect_to with redirect_post (from repost gem) to deal with new
         # Omniauth gem requirements
-        uri = URI(request.original_url)
-        host_port = uri.host + (uri.port == 80) ? '' : ':' + uri.port
-        redirect_post("#{uri.scheme}://#{host_port}/users/auth/saml", options: {authenticity_token: :auto})
+        redirect_post("#{scheme_host_port}/users/auth/saml", options: {authenticity_token: :auto})
       end
     end
 

--- a/app/controllers/blacklight_cornell_requests/request_controller.rb
+++ b/app/controllers/blacklight_cornell_requests/request_controller.rb
@@ -28,11 +28,6 @@ module BlacklightCornellRequests
     end
 
     def auth_magic_request target=''
-      uri = URI(request.original_url)
-      scheme_host = "#{uri.scheme}://#{uri.host}"
-      if uri.port.present? && uri.port !=  uri.default_port()
-        scheme_host = scheme_host + ':' + uri.port.to_s
-      end
       id_format = params[:format].present? ? params[:bibid] + '.' + params[:format] : params[:bibid]
       session[:cuwebauth_return_path] = magic_request_path(id_format)
       Rails.logger.debug "es287_log #{__FILE__} #{__LINE__}: #{magic_request_path(id_format).inspect}"
@@ -41,6 +36,11 @@ module BlacklightCornellRequests
       else
         # Replace redirect_to with redirect_post (from repost gem) to deal with new
         # Omniauth gem requirements
+        uri = URI(request.original_url)
+        scheme_host = "#{uri.scheme}://#{uri.host}"
+        if uri.port.present? && uri.port !=  uri.default_port()
+          scheme_host = scheme_host + ':' + uri.port.to_s
+        end
         redirect_post("#{scheme_host}/users/auth/saml", options: {authenticity_token: :auto})
       end
     end

--- a/app/controllers/blacklight_cornell_requests/request_controller.rb
+++ b/app/controllers/blacklight_cornell_requests/request_controller.rb
@@ -29,7 +29,10 @@ module BlacklightCornellRequests
 
     def auth_magic_request target=''
       uri = URI(request.original_url)
-      scheme_host_port = "#{uri.scheme}://#{uri.host}" + (uri.port == 80) ? '' : ':' + uri.port
+      scheme_host = "#{uri.scheme}://#{uri.host}"
+      if uri.port.present? && uri.port !=  uri.default_port()
+        scheme_host = scheme_host + ':' + uri.port
+      end
       id_format = params[:format].present? ? params[:bibid] + '.' + params[:format] : params[:bibid]
       session[:cuwebauth_return_path] = magic_request_path(id_format)
       Rails.logger.debug "es287_log #{__FILE__} #{__LINE__}: #{magic_request_path(id_format).inspect}"
@@ -43,7 +46,7 @@ msg = [" #{__method__} ".center(60,'Z')]
 msg << jgr25_context
 msg << "request.original_url: " + request.original_url.inspect
 msg << "uri: " + uri.inspect
-msg << "scheme_host_port: " + scheme_host_port.inspect
+msg << "scheme_host: " + scheme_host.inspect
 msg << 'Z' * 60
 msg.each { |x| puts 'ZZZ ' + x.to_yaml }
 Rails.logger.level = save_level

--- a/app/controllers/blacklight_cornell_requests/request_controller.rb
+++ b/app/controllers/blacklight_cornell_requests/request_controller.rb
@@ -29,6 +29,20 @@ module BlacklightCornellRequests
 
     def auth_magic_request target=''
       uri = URI(request.original_url)
+#******************
+save_level = Rails.logger.level; Rails.logger.level = Logger::WARN
+msg.each { |x| puts 'ZZZ ' + x.to_yaml }
+jgr25_context = "#{__FILE__}:#{__LINE__}"
+Rails.logger.warn "jgr25_log\n#{jgr25_context}:"
+msg = [" #{__method__} ".center(60,'Z')]
+msg << jgr25_context
+msg << "request.original_url: " + request.original_url.inspect
+msg << "uri: " + uri.inspect
+msg << 'Z' * 60
+msg.each { |x| puts 'ZZZ ' + x.to_yaml }
+Rails.logger.level = save_level
+#binding.pry
+#*******************
       scheme_host = "#{uri.scheme}://#{uri.host}"
       if uri.port.present? && uri.port !=  uri.default_port()
         scheme_host = scheme_host + ':' + uri.port


### PR DESCRIPTION
This branch has the updated login code in app/controllers/blacklight_cornell_requests/request_controller.rb
This code builds the current application's URL based on request.original_url. The previous code used request fields that are no longer available in gem 'rails', '5.2.6.3'.
This also uses the redirect_post replacement for redirect_to from https://github.com/vergilet/repost
The sends the request to omniauth via POST instead of GET - a new requirement.