### PR TITLE
DACCESS-179 - Update to "BorrowDirect"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Blacklight Cornell Requests
 
 ## Overview
-This project is a Rails engine designed to plug into a [Blacklight](http://projectblacklight.org) instance. It provides functionality for placing requests for materials via Voyager methods (callslip, hold, recall), document delivery, [BorrowDirect](http://www.borrowdirect.org/), interlibrary loan, and more. However, the current codebase is tightly integrated with [Cornell's Blacklight catalog](https://newcatalog.library.cornell.edu).
+This project is a Rails engine designed to plug into a [Blacklight](http://projectblacklight.org) instance. It provides functionality for placing requests for materials via Voyager methods (callslip, hold, recall), document delivery, [BorrowDirect](http://www.borrowdirect.org/), Interlibrary Loan, and more. However, the current codebase is tightly integrated with [Cornell's Blacklight catalog](https://newcatalog.library.cornell.edu).
 
 <p style="text-align: center"><a href="https://zenhub.com"><img src="https://raw.githubusercontent.com/ZenHubIO/support/master/zenhub-badge.png"></a></p>

--- a/app/assets/javascripts/blacklight_cornell_requests/requests.js.coffee
+++ b/app/assets/javascripts/blacklight_cornell_requests/requests.js.coffee
@@ -31,7 +31,7 @@ requests =
       requests.submitPurchaseForm()
       return false
 
-    # ... and for Borrow Direct requests
+    # ... and for BorrowDirect requests
     $('#bd-request-submit').click ->
       $.fn.spin.presets.requesting =
         lines: 9,
@@ -78,8 +78,8 @@ requests =
       this.bindPickupEventListeners()
       this.checkForSingleCopy()
 
-  # If this is a borrow direct request, modify the values in the location select
-  # list to use the Borrow Direct location codes instead of CUL codes
+  # If this is a BorrowDirect request, modify the values in the location select
+  # list to use the BorrowDirect location codes instead of CUL codes
   checkForBD: () ->
     if $('form#req.bd-request').length == 1
       options = $('#pickup-locations option')
@@ -151,9 +151,10 @@ requests =
       success: (data) ->
         $('#request-loading-spinner').spin(false)
 
-        # Ugly special condition wrangling for Borrow Direct messages,
+        # Ugly special condition wrangling for BorrowDirect messages,
         # which are _mostly_ not treated as ordinary flash messages!
-        match = data.match(/Borrow Direct/gi)
+        # support matching "Borrow Direct" or "BorrowDirect"
+        match = data.match(/Borrow\s?Direct/gi)
         error = data.match(/error/gi)
         if (source == 'bd' && match)
           $('#request-message-well').html(data)

--- a/app/controllers/blacklight_cornell_requests/request_controller.rb
+++ b/app/controllers/blacklight_cornell_requests/request_controller.rb
@@ -524,10 +524,10 @@ module BlacklightCornellRequests
         result = request_from_reshare(patron: user, item: params[:bd_id], pickup_location: params[:library_id], note: params[:reqcomments])
         if result == :error
           status = 'failure'
-          status_msg = 'There was an error when submitting this request to Borrow Direct. Your request could not be completed.'
+          status_msg = 'There was an error when submitting this request to BorrowDirect. Your request could not be completed.'
         else
           status = 'success'
-          status_msg = I18n.t('requests.success') + " The Borrow Direct request number is #{result}."
+          status_msg = I18n.t('requests.success') + " The BorrowDirect request number is #{result}."
         end
         render :partial => 'bd_notification', :layout => false, locals: { :message => status_msg, :status => status }
       end

--- a/app/helpers/blacklight_cornell_requests/request_helper.rb
+++ b/app/helpers/blacklight_cornell_requests/request_helper.rb
@@ -44,7 +44,7 @@ module BlacklightCornellRequests
     # Provide a list of delivery locations that can be used to build options for a select dropdown
     # Doing it this way to make it easier to mark a default location as selected in HAML....
     def pickup_locations
-      # Borrow Direct requests need to provide a library-specific BD code, provided here
+      # BorrowDirect requests need to provide a library-specific BD code, provided here
       bd_codes = {
         '7c5abc9f-f3d7-4856-b8d7-6712462ca007' => 'F', # Africana
         'ab1fce49-e832-41a4-8afc-7179a62332e2' => 'I', # Catherwood ILR

--- a/app/models/blacklight_cornell_requests/delivery_method.rb
+++ b/app/models/blacklight_cornell_requests/delivery_method.rb
@@ -164,7 +164,7 @@ module BlacklightCornellRequests
     TemplateName = 'bd'
 
     def self.description
-      'Borrow Direct'
+      'BorrowDirect'
     end
 
     def self.enabled?
@@ -179,7 +179,7 @@ module BlacklightCornellRequests
 
     # patron is a Patron instance; holdings is a holdings_json object from the bib record @document
     def self.available?(patron, holdings)
-      # NOTE: In transitioning from the old Borrow Direct system to ReShare, we are eliminating the distinction
+      # NOTE: In transitioning from the old BorrowDirect system to ReShare, we are eliminating the distinction
       # between BD and ILL, routing all requests into a single ILL form from which ReShare will figure out how to
       # fulfill them. The most expedient way to remove the old BD approach from the system is to always return
       # false for method availability.

--- a/app/views/blacklight_cornell_requests/request/bd.html.haml
+++ b/app/views/blacklight_cornell_requests/request/bd.html.haml
@@ -3,7 +3,7 @@
 - @selected_volume = params[:volume]
 = render :partial => 'shared/back_to_item'
 %h2
-  = "Borrow Direct Request for #{@netid}"
+  = "BorrowDirect Request for #{@netid}"
 %div.card
   %div.card-body
     %h3.item-title-request.blacklight-title_display
@@ -31,13 +31,13 @@
             %textarea(name="reqcomments" id="reqcomments" class="form-control")
         %input(type="hidden" name="bd_id" value="#{@bd_id}" id="bd_id")
         %div.clearfix
-          %input#bd-request-submit.btn.btn-danger.pull-left(type="submit" name="submit" value="Submit Borrow Direct request")
+          %input#bd-request-submit.btn.btn-danger.pull-left(type="submit" name="submit" value="Submit BorrowDirect request")
           %span{:id => 'request-loading-spinner'}
         %div#request-message-well
 
     - else
-      %p To request this item, search Borrow Direct  and place a request.
-      = link_to 'Search Borrow Direct', borrowdirect_url_from_title(@ti), :class => 'btn btn-danger pull-left'
+      %p To request this item, search BorrowDirect  and place a request.
+      = link_to 'Search BorrowDirect', borrowdirect_url_from_title(@ti), :class => 'btn btn-danger pull-left'
 
     -if @alternate_methods && @alternate_methods.count > 1
       = render :partial => 'shared/request_options'

--- a/app/views/blacklight_cornell_requests/request/ill.html.haml
+++ b/app/views/blacklight_cornell_requests/request/ill.html.haml
@@ -11,9 +11,9 @@
     %div.request-author=@au
     %p
       %strong
-        BorrowDirect and interlibrary loan requests have been combined. Your request will be fulfilled using the fastest method available.
+        BorrowDirect and Interlibrary Loan requests have been combined. Your request will be fulfilled using the fastest method available.
     %p
-      To request this item, complete the interlibrary loan form by clicking the button below.
+      To request this item, complete the Interlibrary Loan form by clicking the button below.
     %p
       - if !@estimate.blank?
         Delivery time: 

--- a/app/views/blacklight_cornell_requests/request/ill.html.haml
+++ b/app/views/blacklight_cornell_requests/request/ill.html.haml
@@ -1,5 +1,5 @@
 = render :partial => 'shared/back_to_item'
-%h2 Borrow Direct & Interlibrary Loan
+%h2 BorrowDirect & Interlibrary Loan
 %div.card
   %div.card-body
     %h3.item-title-request.blacklight-title_display
@@ -11,7 +11,7 @@
     %div.request-author=@au
     %p
       %strong
-        Borrow Direct and interlibrary loan requests have been combined. Your request will be fulfilled using the fastest method available.
+        BorrowDirect and interlibrary loan requests have been combined. Your request will be fulfilled using the fastest method available.
     %p
       To request this item, complete the interlibrary loan form by clicking the button below.
     %p
@@ -20,7 +20,7 @@
         = delivery_estimate_display @estimate
     .clearfix
       %a{:href => @ill_link, :class => 'btn btn-danger pull-left'}
-        Go to the Borrow Direct/Interlibrary Loan Form
+        Go to the BorrowDirect/Interlibrary Loan Form
     -if @alternate_methods && @alternate_methods.count > 1
       = render :partial => 'shared/request_options'
     -else

--- a/app/views/shared/_request_options.html.haml
+++ b/app/views/shared/_request_options.html.haml
@@ -27,7 +27,7 @@
               %td
                 = link_to request_bd_path(@id), {:title => @ti} do
                   %i.fa.fa-arrow-circle-right
-                  Borrow Direct
+                  BorrowDirect
               %td 
                 approximately 
                 = delivery_estimate_display BlacklightCornellRequests::BD.time

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -14,7 +14,7 @@ After restarting the Blacklight server, Requests should be accessible at `/reque
 ## Important files
 
 ## Important external systems
-Requests communicates with FOLIO (to determine whether holds, recalls, and pages can be placed for an item, and to place those types of requests), Borrow Direct, and ILLiad.
+Requests communicates with FOLIO (to determine whether holds, recalls, and pages can be placed for an item, and to place those types of requests), BorrowDirect, and ILLiad.
 
 ## Authentication and debugging without SAML
 By default, Requests uses SAML authentication to authenticate a user and retrieve a netid (see the `authenticate_user` and `user` methods in `my_account_controller.rb`). Since SAML is a little tricky to get up and running on an individual development machine, there is a workaround. If Blacklight/Rails is running in `development` mode, a special key can be added to the Blacklight `.env` file: `DEBUG_USER=<netid>`. (This has no effect if Rails is running in `production` mode, to prevent bad things from happening. This value can also be used to debug the MyAccount engine.) In that case, SAML authentication is bypassed and Requests loads with the account information for the specified netid.

--- a/doc/envkeys.md
+++ b/doc/envkeys.md
@@ -40,13 +40,13 @@
 	ORACLE_SID=<Oracle SID>
 	REQUEST_URL=<URL for Voyager request services>
 	REST_URL=<URL to the Voyager REST services URL>
-	BORROW_DIRECT_PROD_API_KEY=<API key for Borrow Direct web services>
-	BORROW_DIRECT_TEST_API_KEY=<API key for Borrow Direct test web services>
+	BORROW_DIRECT_PROD_API_KEY=<API key for BorrowDirect web services>
+	BORROW_DIRECT_TEST_API_KEY=<API key for BorrowDirect test web services>
 	BORROW_DIRECT_URL=<TEST|PRODUCTION>
-	BORROW_DIRECT_TIMEOUT=<Borrow Direct timeout in seconds>
+	BORROW_DIRECT_TIMEOUT=<BorrowDirect timeout in seconds>
 
 ### Disabling services
-Most delivery services can be “disabled” (i.e., won’t be offered as choices in the Requests system, though of course this has no effect on the services themselves). This is achieved by adding an appropriate key to the `.env` file. For example, `DISABLE_BORROW_DIRECT=1` will remove Borrow Direct from the equation. The exact key value doesn’t matter so long as it evaluates as `true` using Rails’ `present?` method; thus, it’s best to remove the key-value pair entirely when re-enabling the service.
+Most delivery services can be “disabled” (i.e., won’t be offered as choices in the Requests system, though of course this has no effect on the services themselves). This is achieved by adding an appropriate key to the `.env` file. For example, `DISABLE_BORROW_DIRECT=1` will remove BorrowDirect from the equation. The exact key value doesn’t matter so long as it evaluates as `true` using Rails’ `present?` method; thus, it’s best to remove the key-value pair entirely when re-enabling the service.
 
 This feature can be used, for example, if Voyager services should be made temporarily unavailable during a system upgrade.
 

--- a/lib/blacklight_cornell_requests/version.rb
+++ b/lib/blacklight_cornell_requests/version.rb
@@ -1,3 +1,3 @@
 module BlacklightCornellRequests
-  VERSION = "4.4"
+  VERSION = "4.4.1"
 end

--- a/lib/reshare.rb
+++ b/lib/reshare.rb
@@ -29,7 +29,7 @@ module Reshare
     {}
   end
 
-  # Use the ReShare APIs to place a Borrow Direct request. Return the created request's ID if successful, :error otherwise.
+  # Use the ReShare APIs to place a BorrowDirect request. Return the created request's ID if successful, :error otherwise.
   def request_from_reshare(patron:, item:, pickup_location:, note:)
     url = "#{ENV['RESHARE_REQUEST_URL']}?svc_id=json&req_id=#{patron}&rft_id=#{item}&svc.pickupLocation=#{pickup_location}&res.org=ISIL%3AUS-NIC"
     url += "&svc.note=" + note.to_s.html_safe if note.present?

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,5 +1,8 @@
 # Release Notes - blacklight-cornell-requests
 
+## 4.4.1
+- Change references from Borrow Direct to BorrowDirect (DACCESS-179)
+
 ## 4.4 (Microfiche update)
 - Add special handling for microfiche at Annex with 'acc,anx' location.
 


### PR DESCRIPTION
DACCESS-179 - Update "Borrow Direct" to "BorrowDirect" spelling in Requests system

@Baroquem could double check the delivery_method.rb description change is not going to cause problems? I couldn't find its usage anywhere, it seems safe like this would be for display purposes