### PR TITLE
DACCESS-207: Update dependencies for FOLIO Poppy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,31 +3,16 @@ source "http://rubygems.org"
 # Declare your gem's dependencies in blacklight_cornell_requests.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and
 # development dependencies will be added by default to the :development group.
-gem "thor"
-#gem 'zoom', :git => 'https://github.com/bricestacey/ruby-zoom.git'
-#gem 'blacklight', '5.9'
-gem 'rails', '~> 6.1'
-gem 'unf_ext'
 
 gemspec
-
-# jquery-rails is used by the dummy application
-gem "jquery-rails"
-
-#gem "thor"
-
-
-group :test do
-  gem "mocha"
-  gem "ci_reporter"
-end
 
 # Declare any dependencies that are still in development here instead of in
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing
 # your gem to rubygems.org.
 
+gem 'cul-folio-edge', '2.0', git: 'https://github.com/cul-it/cul-folio-edge'
+
 # To use debugger
 # gem 'debugger'
 
-gem 'cul-folio-edge', '2.0', git: 'https://github.com/cul-it/cul-folio-edge'

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gemspec
 # Git. Remember to move these dependencies to your gemspec before releasing
 # your gem to rubygems.org.
 
-gem 'cul-folio-edge', '2.0', git: 'https://github.com/cul-it/cul-folio-edge'
+gem 'cul-folio-edge', '~> 3.0', git: 'https://github.com/cul-it/cul-folio-edge'
 
 # To use debugger
 # gem 'debugger'

--- a/blacklight_cornell_requests.gemspec
+++ b/blacklight_cornell_requests.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", "~> 6.1"
   s.add_dependency 'protected_attributes_continued'
-  # s.add_dependency "jquery-rails"
   s.add_dependency 'haml', ['>= 3.0.0']
   s.add_dependency 'haml-rails'
   s.add_dependency 'httpclient'
@@ -32,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activerecord-oracle_enhanced-adapter'
   s.add_dependency 'repost'
   s.add_dependency 'rest-client'
-  s.add_dependency 'cul-folio-edge', '~> 2.0'
+  # s.add_dependency 'cul-folio-edge', '~> 2.0'
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails", "~> 2.5"

--- a/lib/blacklight_cornell_requests/version.rb
+++ b/lib/blacklight_cornell_requests/version.rb
@@ -1,3 +1,3 @@
 module BlacklightCornellRequests
-  VERSION = "4.4.1"
+  VERSION = "5.0"
 end

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,5 +1,11 @@
 # Release Notes - blacklight-cornell-requests
 
+## [5.0] - 2024-05-01
+
+### Changed
+- Require v3.0 of `cul-folio-edge` for placing FOLIO requests
+- Clean up Gemfile and gemspec
+
 ## 4.4.1
 - Change references from Borrow Direct to BorrowDirect (DACCESS-179)
 - Enable ILL requests for Paged items (DACCESS-202)


### PR DESCRIPTION
https://culibrary.atlassian.net/browse/DACCESS-207

This updates the dependency on `cul-folio-edge` in response to Poppy API changes. Also includes some cleanup work on the Gemfile and gemspec.